### PR TITLE
implement disableDragClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ __[Demo](http://jakesidsmith.github.io/react-reorderable/)__
       template={ListItem},
       // Function that is called once a reorder has been performed
       callback={this.callback},
+      // disables drag for a given css class (use on buttons/links inside reorderable items)
+      disableDragClass='no-drag',
       // Class to be applied to the outer list element
       listClass='my-list',
       // Class to be applied to each list item's wrapper element

--- a/reorderable.js
+++ b/reorderable.js
@@ -32,6 +32,15 @@
         }
       },
       itemDown: function (item, index, event) {
+        var dragDisabledForTarget = event.
+          target.
+          classList.
+          contains(this.props.disableDragClass);
+
+        if (dragDisabledForTarget) {
+          return false;
+        }
+
         event.preventDefault();
         this.handleTouchEvents(event);
         var self = this;


### PR DESCRIPTION
this gives users the option to disable drag on elements inside
their reorderable list. This is helpful for buttons and links
who's events would otherwise be clobbered without this option.
