### PR TITLE
fix dismounting groups throwing unknown id error

### DIFF
--- a/examples/src/js/index.js
+++ b/examples/src/js/index.js
@@ -152,6 +152,12 @@ class Main extends Component {
     });
   }
 
+  onDismountToggle () {
+    this.setState({
+      dismountGroups: !this.state.dismountGroups
+    });
+  }
+
   onPrefixChange (event) {
     const target = event.currentTarget;
 
@@ -299,72 +305,84 @@ class Main extends Component {
         <p>
           This example has a group of lists that you can drag items between
         </p>
+        <p>
+          {'Dismount reorder: '}
+          <input
+            type="checkbox"
+            value={this.state.dismountGroups || false}
+            onChange={this.onDismountToggle.bind(this)}
+          />
+        </p>
 
-        <Reorder
-          reorderId="listA"
-          reorderGroup="reorderGroup"
-          component="ul"
-          className={[classNames.myList, classNames.multiList].join(' ')}
-          placeholderClassName={classNames.placeholder}
-          draggedClassName={classNames.dragged}
-          onReorder={this.onReorderGroup.bind(this)}
-        >
-          {
-            this.state.listA.map(function (item) {
-              return (
-                <li
-                  key={item.name}
-                  className={[classNames.listItem, classNames.multiListItem].join(' ')}
-                  style={{color: item.color}}
-                >
-                  <div className={classNames.contentHolder}>
-                    <span className={classNames.itemName}>
-                      {item.name}
-                    </span>
-                    <input
-                      className={classNames.input}
-                      type="text"
-                      defaultValue="Change me, I  sort of retain this state!"
-                    />
-                  </div>
-                </li>
-              );
-            }.bind(this)).toArray()
-          }
-        </Reorder>
+        {!this.state.dismountGroups &&
+          <Reorder
+            reorderId="listA"
+            reorderGroup="reorderGroup"
+            component="ul"
+            className={[classNames.myList, classNames.multiList].join(' ')}
+            placeholderClassName={classNames.placeholder}
+            draggedClassName={classNames.dragged}
+            onReorder={this.onReorderGroup.bind(this)}
+          >
+            {
+              this.state.listA.map(function (item) {
+                return (
+                  <li
+                    key={item.name}
+                    className={[classNames.listItem, classNames.multiListItem].join(' ')}
+                    style={{color: item.color}}
+                  >
+                    <div className={classNames.contentHolder}>
+                      <span className={classNames.itemName}>
+                        {item.name}
+                      </span>
+                      <input
+                        className={classNames.input}
+                        type="text"
+                        defaultValue="Change me, I  sort of retain this state!"
+                      />
+                    </div>
+                  </li>
+                );
+              }.bind(this)).toArray()
+            }
+          </Reorder>
+        }
 
-        <Reorder
-          reorderId="listB"
-          reorderGroup="reorderGroup"
-          component="ul"
-          className={[classNames.myList, classNames.multiList].join(' ')}
-          placeholderClassName={classNames.placeholder}
-          draggedClassName={classNames.dragged}
-          onReorder={this.onReorderGroup.bind(this)}
-        >
-          {
-            this.state.listB.map(function (item) {
-              return (
-                <li
-                  key={item.name}
-                  className={[classNames.listItem, classNames.multiListItem].join(' ')}
-                  style={{color: item.color}}
-                >
-                  <div className={classNames.contentHolder}>
-                    <span className={classNames.itemName}>
-                      {item.name}
-                    </span>
-                    <input
-                      className={classNames.input}
-                      type="text"
-                      defaultValue="Change me, I  sort of retain this state!"
-                    />
-                  </div>
-                </li>
-              );
-            }.bind(this)).toArray()
-          }
-        </Reorder>
+        {!this.state.dismountGroups &&
+          <Reorder
+            reorderId="listB"
+            reorderGroup="reorderGroup"
+            component="ul"
+            className={[classNames.myList, classNames.multiList].join(' ')}
+            placeholderClassName={classNames.placeholder}
+            draggedClassName={classNames.dragged}
+            onReorder={this.onReorderGroup.bind(this)}
+          >
+            {
+              this.state.listB.map(function (item) {
+                return (
+                  <li
+                    key={item.name}
+                    className={[classNames.listItem, classNames.multiListItem].join(' ')}
+                    style={{color: item.color}}
+                  >
+                    <div className={classNames.contentHolder}>
+                      <span className={classNames.itemName}>
+                        {item.name}
+                      </span>
+                      <input
+                        className={classNames.input}
+                        type="text"
+                        defaultValue="Change me, I  sort of retain this state!"
+                      />
+                    </div>
+                  </li>
+                );
+              }.bind(this)).toArray()
+            }
+          </Reorder>
+        }
       </div>
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -58,10 +58,6 @@
     function registerReorderComponent (reorderId, reorderGroup, callback) {
       validateComponentIdAndGroup(reorderId, reorderGroup);
 
-      if (reorderId in reorderComponents) {
-        throw new Error('Duplicate reorderId: ' + reorderId);
-      }
-
       if (typeof reorderGroup !== 'undefined') {
         if ((reorderGroup in reorderGroups) && (reorderId in reorderGroups[reorderGroup])) {
           throw new Error('Duplicate reorderId: ' + reorderId + ' in reorderGroup: ' + reorderGroup);
@@ -70,16 +66,16 @@
         reorderGroups[reorderGroup] = reorderGroups[reorderGroup] || {};
         reorderGroups[reorderGroup][reorderId] = callback;
       } else {
+        if (reorderId in reorderComponents) {
+          throw new Error('Duplicate reorderId: ' + reorderId);
+        }
+
         reorderComponents[reorderId] = callback;
       }
     }
 
     function unregisterReorderComponent (reorderId, reorderGroup) {
       validateComponentIdAndGroup(reorderId, reorderGroup);
-
-      if (!(reorderId in reorderComponents)) {
-        throw new Error('Unknown reorderId: ' + reorderId);
-      }
 
       if (typeof reorderGroup !== 'undefined') {
         if (!(reorderGroup in reorderGroups)) {
@@ -92,6 +88,10 @@
 
         delete reorderGroups[reorderGroup][reorderId];
       } else {
+        if (!(reorderId in reorderComponents)) {
+          throw new Error('Unknown reorderId: ' + reorderId);
+        }
+
         delete reorderComponents[reorderId];
       }
     }


### PR DESCRIPTION
This fixes the issue described in https://github.com/JakeSidSmith/react-reorder/issues/78#issuecomment-296424877.

You may not want to merge this directly as it does contain a change to the examples that isn't overly useful outside of testing this issue, but it was left there for a convenient way to confirm this was broken and now isn't.